### PR TITLE
Update run_benchmark.py

### DIFF
--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -63,7 +63,7 @@ async def run_fastapi_benchmark_async(num_requests):
     results_list = [] # To store results for final count
     
     # Configure httpx limits
-    limits = httpx.Limits(max_connections=500, max_keepalive_connections=50)
+    limits = httpx.Limits(max_connections=1000, max_keepalive_connections=50)
     async with httpx.AsyncClient(limits=limits) as client:
         tasks = [fetch_url_async(client, FASTAPI_URL) for _ in range(num_requests)]
         


### PR DESCRIPTION
new limit, this change will make it so there are not errors on the fastAPI when using 1000 threads, another option could be changing the pool timeout on httpx but that would make it unfair comparison.